### PR TITLE
Possibility to ignore the title

### DIFF
--- a/plugins/title.js
+++ b/plugins/title.js
@@ -39,6 +39,10 @@ function extractYoutubeTitle(match, callback) {
 
 module.exports = function(bot, options) {
   bot.irc.on('privmsg', function(from, channel, msg) {
+    if (/^\s*!/.exec(msg)) {
+      return
+    }
+
     var imgur = /https?:\/\/(?:www\.)?imgur\.com\/gallery\/[^\s]+/.exec(msg)
 
     if (imgur) {


### PR DESCRIPTION
Precede the imgur or youtube link with a ! and the title won't be parsed. Good for rickrolling.
