### PR TITLE
build(docker): add rudimentary Dockerfile for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:10-alpine
+
+ENV TZ=Europe/Zurich
+
+RUN adduser -D nib
+WORKDIR /home/nib
+
+COPY bin/ ./bin/
+COPY lib/ ./lib/
+COPY plugins/ ./plugins/
+COPY package.json package-lock.json* ./
+COPY index.js ./
+
+RUN chown -R nib:nib .
+USER nib
+
+RUN npm install
+
+CMD ["./bin/nib.js"]


### PR DESCRIPTION
The file sports a default timezone for Switzerland and runs the script as an unprivileged user.

The `COPY` part could probably be simplified to make the build faster and/or resulting image smaller. I'm open to suggestions :smiley: 